### PR TITLE
マイページ ページ表示されないエラーの解消

### DIFF
--- a/src/php/admin/auth.php
+++ b/src/php/admin/auth.php
@@ -10,9 +10,15 @@ if(!empty($_SESSION['login_date'])){
     } else {
         debug('ログイン有効期限以内です。');
         $_SESSION['login_date'] = time();
-        debug('マイページに遷移します。');
-        header('Location:mypage.php');
+
+        if(basename($_SERVER['PHP_SELF'] === 'signin.php')){
+            debug('マイページに遷移します。');
+            header('Location:mypage.php');
+        }
     }
 } else {
     debug('未ログインのユーザです。');
+    if(basename($_SERVER['PHP_SELF']) !== 'signin.php'){
+        header('Location:signin.php');
+    }
 }

--- a/src/php/admin/changepass.php
+++ b/src/php/admin/changepass.php
@@ -39,7 +39,7 @@ if(!empty($_POST)){
             try {
                 $dbh = dbConnect();
                 $sql = 'UPDATE users SET pass = :pass WHERE id = :id';
-                $data = array(':id' => $_SESSION['user_id'], ':pass' => $new_pass);
+                $data = array(':id' => $_SESSION['user_id'], ':pass' => password_hash($new_pass, PASSWORD_DEFAULT));
                 $stmt = queryPost($dbh, $sql, $data);
 
                 if($stmt){

--- a/src/php/admin/function.php
+++ b/src/php/admin/function.php
@@ -14,7 +14,7 @@ $debug_flg = true;
 function debug($value){
     global $debug_flg;
     if(!empty($debug_flg)){
-        error_log('デバッグ'.$value);
+        error_log('デバッグ:'.$value);
     }
 }
 
@@ -154,6 +154,7 @@ function sendMail($from, $to, $subject, $comment){
 
 /* ユーザ情報取得 */
 function getUser($userID){
+    debug('ユーザ情報を取得します。');
     try {
         $dbh = dbConnect();
         $sql = 'SELECT * FROM users WHERE id = :userID AND delete_flg = 0';
@@ -169,3 +170,5 @@ function getUser($userID){
         error_log('エラー発生:'.$e->getMessage());
     }
 }
+
+?>

--- a/src/php/admin/mypage.php
+++ b/src/php/admin/mypage.php
@@ -6,6 +6,7 @@ debug('「「「「「「「「「「「「「「「「「「「「「「「「�
 debugLogStart();
 require('auth.php');
 
+$userData = getUser($_SESSION['user_id']);
 ?>
 
 <?php include('./common/head.php'); ?>
@@ -19,8 +20,8 @@ require('auth.php');
                 <img src="/images/default.jpg" alt="" class="c-myself__thumb">
             </div>
             <div class="c-myself__contents">
-                <p class="c-myself__text">名前：xxx xxxxx</p>
-                <p class="c-myself__text">メールアドレス：xxxx@xxxxxx.xx.xx</p>
+                <p class="c-myself__text">名前：<?php echo $userData['username'] ; ?></p>
+                <p class="c-myself__text">メールアドレス：<?php echo $userData['email'] ; ?></p>
             </div>
 
             <a href="/admin/myself.php" class="c-myself__link c-btn c-btn--green">編集</a>

--- a/src/php/admin/signin.php
+++ b/src/php/admin/signin.php
@@ -8,20 +8,21 @@ require('auth.php');
 
 
 if(!empty($_POST)){
-    $name = $_POST['name'];
+    $email = $_POST['email'];
     $pass = $_POST['pass'];
 
-    validRequired($name, 'empty');
+    validRequired($email, 'empty');
     validRequired($pass, 'empty');
         
     validHarf($pass, 'pass');
     validMinLength($pass, 'pass');
     validMaxLength($pass, 'pass');
+
     if(empty($err_msg)){
         try {
             $dbh = dbConnect();
-            $sql = 'SELECT pass,id FROM users WHERE username = :username AND pass = :pass';
-            $data = array(':username' => $name, ':pass' => $pass);
+            $sql = 'SELECT pass,id  FROM users WHERE email = :email AND delete_flg = 0';
+            $data = array(':email' => $email);
             $stmt = queryPost($dbh, $sql, $data);
 
             $result = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -66,8 +67,8 @@ if(!empty($_POST)){
 
         <form method="post" class="c-form">
             <label for="name" class="c-form__label">
-                名前
-                <input type="text" name="name" class="c-form__input" value="<?php if(!empty($_POST['name'])) echo $_POST['name'] ;?>">
+                メールアドレス
+                <input type="text" name="email" class="c-form__input" value="<?php if(!empty($_POST['email'])) echo $_POST['email'] ;?>">
             </label>
 
             <label for="pass" class="c-form__label">

--- a/src/php/admin/signout.php
+++ b/src/php/admin/signout.php
@@ -1,7 +1,12 @@
 <?php
-
 require('function.php');
 
-session_destroy();
+debug('「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「');
+debug('「　ログアウトページ　');
+debug('「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「「');
+debugLogStart();
 
+debug('ログアウトします。');
+session_destroy();
+debug('ログインページへ遷移します。');
 header('Location:signin.php');

--- a/src/php/admin/signup.php
+++ b/src/php/admin/signup.php
@@ -42,7 +42,7 @@ if(!empty($_POST)){
                     $sesLimit = 60*60;
                     $_SESSION['login_date']  = time();
                     $_SESSION['login_limit'] = $sesLimit;
-                    $_SESSION['user_id']     = $result['id'];
+                    $_SESSION['user_id']     = $dbh->lastInsertId();
 
                     debug('セッション変数の中身:'.print_r($_SESSION, true));
                     


### PR DESCRIPTION
- mypage.php無限リダイレクト解消
auth.phpに記載してるheader()のリダイレクト先が自身だったので条件分岐を追加して対応。
- パスワードハッシュ
エラー解消に合わせてパスワード変更時のハッシュ化を実装
- $_SESSIONが空
渡していた変数自体が間違っていたため修正して対応

`WIP デバッグ出力とログイン認証`と合わせて対応した